### PR TITLE
4x4行列転置を用いたversionを追加した。

### DIFF
--- a/force_aos.cpp
+++ b/force_aos.cpp
@@ -340,6 +340,95 @@ force_intrin(void) {
 }
 //----------------------------------------------------------------------
 void
+force_intrin_mat_transpose(void) {
+  const v4df vzero = _mm256_set_pd(0, 0, 0, 0);
+  const v4df vcl2 = _mm256_set_pd(CL2, CL2, CL2, CL2);
+  const v4df vc24 = _mm256_set_pd(24 * dt, 24 * dt, 24 * dt, 24 * dt);
+  const v4df vc48 = _mm256_set_pd(48 * dt, 48 * dt, 48 * dt, 48 * dt);
+  const int pn = particle_number;
+  for (int i = 0; i < pn; i++) {
+    const v4df vqi = _mm256_load_pd((double*)(q + i));
+    v4df vpi = _mm256_load_pd((double*)(p + i));
+    const int np = number_of_partners[i];
+    const int kp = pointer[i];
+    for (int k = 0; k < (np / 4) * 4; k += 4) {
+      const int j_a = sorted_list[kp + k];
+      v4df vqj_a = _mm256_load_pd((double*)(q + j_a));
+      v4df vdq_a = (vqj_a - vqi);
+
+      const int j_b = sorted_list[kp + k + 1];
+      v4df vqj_b = _mm256_load_pd((double*)(q + j_b));
+      v4df vdq_b = (vqj_b - vqi);
+
+      const int j_c = sorted_list[kp + k + 2];
+      v4df vqj_c = _mm256_load_pd((double*)(q + j_c));
+      v4df vdq_c = (vqj_c - vqi);
+
+      const int j_d = sorted_list[kp + k + 3];
+      v4df vqj_d = _mm256_load_pd((double*)(q + j_d));
+      v4df vdq_d = (vqj_d - vqi);
+
+      v4df tmp0 = _mm256_unpacklo_pd(vdq_a, vdq_b);
+      v4df tmp1 = _mm256_unpackhi_pd(vdq_a, vdq_b);
+      v4df tmp2 = _mm256_unpacklo_pd(vdq_c, vdq_d);
+      v4df tmp3 = _mm256_unpackhi_pd(vdq_c, vdq_d);
+
+      v4df vdx = _mm256_permute2f128_pd(tmp0, tmp2, 0x20);
+      v4df vdy = _mm256_permute2f128_pd(tmp1, tmp3, 0x20);
+      v4df vdz = _mm256_permute2f128_pd(tmp0, tmp2, 0x31);
+
+      v4df vr2 = vdx * vdx + vdy * vdy + vdz * vdz;
+      v4df vr6 = vr2 * vr2 * vr2;
+      v4df vdf = (vc24 * vr6 - vc48) / (vr6 * vr6 * vr2);
+      v4df mask = vcl2 - vr2;
+      vdf = _mm256_blendv_pd(vdf, vzero, mask);
+
+      v4df vdf_a = _mm256_permute4x64_pd(vdf, 0);
+      v4df vdf_b = _mm256_permute4x64_pd(vdf, 85);
+      v4df vdf_c = _mm256_permute4x64_pd(vdf, 170);
+      v4df vdf_d = _mm256_permute4x64_pd(vdf, 255);
+
+      v4df vpj_a = _mm256_load_pd((double*)(p + j_a));
+      vpi += vdq_a * vdf_a;
+      vpj_a -= vdq_a * vdf_a;
+      _mm256_store_pd((double*)(p + j_a), vpj_a);
+
+      v4df vpj_b = _mm256_load_pd((double*)(p + j_b));
+      vpi += vdq_b * vdf_b;
+      vpj_b -= vdq_b * vdf_b;
+      _mm256_store_pd((double*)(p + j_b), vpj_b);
+
+      v4df vpj_c = _mm256_load_pd((double*)(p + j_c));
+      vpi += vdq_c * vdf_c;
+      vpj_c -= vdq_c * vdf_c;
+      _mm256_store_pd((double*)(p + j_c), vpj_c);
+
+      v4df vpj_d = _mm256_load_pd((double*)(p + j_d));
+      vpi += vdq_d * vdf_d;
+      vpj_d -= vdq_d * vdf_d;
+      _mm256_store_pd((double*)(p + j_d), vpj_d);
+    }
+    _mm256_store_pd((double*)(p + i), vpi);
+    for (int k = (np / 4) * 4; k < np; k++) {
+      const int j = sorted_list[kp + k];
+      double dx = q[j][X] - q[i][X];
+      double dy = q[j][Y] - q[i][Y];
+      double dz = q[j][Z] - q[i][Z];
+      double r2 = (dx * dx + dy * dy + dz * dz);
+      if (r2 > CL2) continue;
+      double r6 = r2 * r2 * r2;
+      double df = ((24.0 * r6 - 48.0) / (r6 * r6 * r2)) * dt;
+      p[i][X] += df * dx;
+      p[i][Y] += df * dy;
+      p[i][Z] += df * dz;
+      p[j][X] -= df * dx;
+      p[j][Y] -= df * dy;
+      p[j][Z] -= df * dz;
+    }
+  }
+}
+//----------------------------------------------------------------------
+void
 measure(void(*pfunc)(), const char *name) {
   double st = myclock();
   const int LOOP = 100;
@@ -361,6 +450,11 @@ main(void) {
   }
 #elif INTRIN
   measure(&force_intrin, "intrin");
+  for (int i = 0; i < 10; i++) {
+    printf("%.10f %.10f %.10f\n", p[i][X], p[i][Y], p[i][Z]);
+  }
+#elif MAT_TRANSPOSE
+  measure(&force_intrin_mat_transpose, "intrin_mat_transpose");
   for (int i = 0; i < 10; i++) {
     printf("%.10f %.10f %.10f\n", p[i][X], p[i][Y], p[i][Z]);
   }

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-TARGET= aos.out aos_pair.out aos_intrin.out soa.out soa_pair.out soa_intrin.out
+TARGET= aos.out aos_pair.out aos_intrin.out soa.out soa_pair.out soa_intrin.out aos_intrin_mat_transpose.out
 
 all: $(TARGET)
 
@@ -10,6 +10,9 @@ aos_pair.out: force_aos.cpp
 
 aos_intrin.out: force_aos.cpp
 	icpc -O3 -xHOST -std=c++11 -DINTRIN $< -o $@
+
+aos_intrin_mat_transpose.out: force_aos.cpp
+	icpc -O3 -xHOST -std=c++11 -DMAT_TRANSPOSE $< -o $@
 
 soa.out: force_soa.cpp
 	icpc -O3 -xHOST -std=c++11 $< -o $@
@@ -23,10 +26,12 @@ soa_intrin.out: force_soa.cpp
 clean:
 	rm -f $(TARGET)
 
-test: aos_pair.out aos_intrin.out soa_pair.out soa_intrin.out
+test: aos_pair.out aos_intrin.out soa_pair.out soa_intrin.out aos_intrin_mat_transpose.out
 	./aos_pair.out > aos_pair.dat
 	./aos_intrin.out > aos_intrin.dat
+	./aos_intrin_mat_transpose.out > aos_intrin_mat_transpose.dat
 	diff aos_pair.dat aos_intrin.dat
+	diff aos_intrin.dat aos_intrin_mat_transpose.dat
 	./soa_pair.out > soa_pair.dat
 	./soa_intrin.out > soa_intrin.dat
 	diff soa_pair.dat soa_intrin.dat


### PR DESCRIPTION
変位のベクトルを
v4df vdq_a = {dx0, dy0, dz0, 0}
v4df vdq_b = {dx1, dy1, dz1, 0}
v4df vdq_c = {dx2, dy2, dz2, 0}
v4df vdq_d = {dx3, dy3, dz3, 0}

としたときに、vdq_a vdq_b vdq_c vdq_dを4x4の行列とみなして転置をします。

dx0 dy0 dz0 0    dx0 dx1 dx2 dx3
dx1 dy1 dz1 0 -> dy0 dy1 dy2 dy3
dx2 dy2 dz2 0    dz0 dz1 dz2 dz3
dx3 dy3 dz3 0    0   0   0   0

この後で掛け算1回積和2回で距離の二乗を計算するやり方です。
Intel(R) Xeon(R) E5-2603 v3 @ 1.60GHz での測定結果ですが、

(行列転置なし) N=119164, intrin 6.851779 [sec]
(行列転置あり) N=119164, intrin_mat_transpose 5.959642 [sec]

となり少し早くなりました。
